### PR TITLE
Deactive not delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ tests/              - test cases package
 | GET | "/customers/<int:customer_id>" | List the information of the Customer with customer_id | 
 | PUT | "/customers/<int:customer_id>" | Update the the information of Customer with the customer_id  | 
 | DELETE | "/customers/<int:customer_id>" | Delete the Customer with customer_id | 
+| PATCH | "/customers/<int:customer_id>" | Restore a deleted account with customer_id |
 
 ## API Calls
 
@@ -91,7 +92,13 @@ tests/              - test cases package
   
    - Request Body: JSON file containing the updated information of customer.
   
-   - Response: HTTP_200_OK; If customer does not exist, HTTP_404_NOT_FOUND
+   - Response: 
+
+        `HTTP_200_OK`, if found; 
+        
+        `HTTP_404_NOT_FOUND`, if customer does not exist or has been deactivated
+
+        `HTTP_405_METHOD_NOT_ALLOWED`, if updated `status` is `False`
 
 **3. Read a cutomer record based on Customer ID**
 
@@ -134,6 +141,26 @@ tests/              - test cases package
    - Response
   
    - Example
+
+**6. Restore a deleted customer record**
+
+   - Description
+
+        This API call is used to restore a deleted customer record with customer_id from the database.
+
+   - Request URL
+
+        `"/customers/<int:customer_id>"` PATCH request
+  
+   - Request Body
+
+        /
+  
+   - Response
+
+        `HTTP_200_OK` if found and successfully restored
+
+        `HTTP_404_NOT_FOUND` if not found
 
 
 ## How to test

--- a/service/models.py
+++ b/service/models.py
@@ -36,6 +36,9 @@ class Customer(db.Model):
     first_name = db.Column(db.String(63), nullable=False)
     last_name = db.Column(db.String(63), nullable=False)
     address = db.Column(db.String(200), nullable=False)
+    status = db.Column(
+        db.Boolean(), nullable=False, default=True
+    )  # activated by default, deactivated if False
 
     ##################################################
     # Instance Methods
@@ -76,6 +79,7 @@ class Customer(db.Model):
             "first name": self.first_name,
             "last name": self.last_name,
             "address": self.address,
+            "active": self.status,
         }
 
     def deserialize(self, data: dict):
@@ -88,6 +92,12 @@ class Customer(db.Model):
             self.first_name = data["first name"]
             self.last_name = data["last name"]
             self.address = data["address"]
+            if isinstance(data["active"], bool):
+                self.status = data["active"]
+            else:
+                raise DataValidationError(
+                    "Invalid type for boolean [active]: " + str(type(data["active"]))
+                )
         except KeyError as error:
             raise DataValidationError(
                 "Invalid customer: missing " + error.args[0]

--- a/service/models.py
+++ b/service/models.py
@@ -109,6 +109,11 @@ class Customer(db.Model):
             ) from error
         return self
 
+    def deactivate(self):
+        """set the status to false to deactive account"""
+
+        self.status = False
+
     ##################################################
     # Class Methods
     ##################################################

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,7 +17,6 @@ Test Factory to make fake objects for testing
 """
 # from datetime import date
 import factory
-from factory.fuzzy import FuzzyChoice
 
 # from factory.fuzzy import FuzzyChoice, FuzzyDate
 from service.models import Customer
@@ -35,4 +34,5 @@ class CustomerFactory(factory.Factory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     address = factory.Faker("address")
-    status = FuzzyChoice(choices=[True, False])
+    # status = FuzzyChoice(choices=[True, False])
+    status = True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -17,6 +17,7 @@ Test Factory to make fake objects for testing
 """
 # from datetime import date
 import factory
+from factory.fuzzy import FuzzyChoice
 
 # from factory.fuzzy import FuzzyChoice, FuzzyDate
 from service.models import Customer
@@ -34,3 +35,4 @@ class CustomerFactory(factory.Factory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     address = factory.Faker("address")
+    status = FuzzyChoice(choices=[True, False])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,7 @@ class TestCustomer(unittest.TestCase):
         app.config["DEBUG"] = False
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
+        db.drop_all()
         Customer.init_db(app)
 
     @classmethod
@@ -58,6 +59,7 @@ class TestCustomer(unittest.TestCase):
             first_name="Michael",
             last_name="Parker",
             address="1724 Green Acres Road, Rocky Mount, New York, 00000",
+            status=True,
         )
         self.assertEqual(str(customer), "<Customer Michael Parker id=[None]>")
         self.assertTrue(customer is not None)
@@ -67,6 +69,7 @@ class TestCustomer(unittest.TestCase):
         self.assertEqual(
             customer.address, "1724 Green Acres Road, Rocky Mount, New York, 00000"
         )
+        self.assertEqual(customer.status, True)
 
     def test_read_a_customer(self):
         """It should Read a Customer"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,6 +186,14 @@ class TestCustomer(unittest.TestCase):
         data = "this is not a dictionary"
         customer = Customer()
         self.assertRaises(DataValidationError, customer.deserialize, data)
+        data = {
+            "id": 1,
+            "first name": "abc",
+            "last name": "def",
+            "address": "ghi",
+            "active": "not Boolean",
+        }
+        self.assertRaises(DataValidationError, customer.deserialize, data)
 
     def test_find_customer(self):
         """It should Find a Customer by ID"""


### PR DESCRIPTION
1. Add a new field to the schema: status. When a record is active (not deleted), the value will be true. 
2. Modified the logic of delete: Now it will not delete the record from dataset. Instead, it will set status to False.
3. Modified all actions related with read. Now a deactivated record will not be visible for most of actions. 
4. Add a new endpoint PATCH for restoring the account.
5. Because there is a change of the schema, I add a drop_all() before all test, which will reset the database. 
6. Updat README.md file